### PR TITLE
Db change dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,10 @@ Notebooks are found in the `Notebooks` folder. You will also note there is a tab
 # Front end
 
 We have implemented a grafana front end, and have some data being displayed on the website. However these are not currently open resources.
+
+
+# Development
+
+To develop the code, we generally test into a newly created DB. Running python files from your 'personal'
+user on the controller PC. Files on the remote (rasberry pi for example) computer should not be deleted.
+This can be done using the variable `drop_recent_files_lX`, obviously setting this to false.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and ingest the data. In cases where there is an `_L#`, there can be 4 different
 versions of this variable for the 4 data quality levels.
 
  * `data_dir`: Directory on the munkholmen raspberry pi where data files are found
- * `file_regex_l#`: Regex used to match files in `data_dir` (or list of regex's). This is the main
+ * `file_search_l#`: Regex used to match files in `data_dir` (or list of regex's). This is the main
  controller for the 'level', setting this to None will mean the level is ignored in rsync/ingest.
  * `drop_recent_files_l#`: Number of latest files to ignore (in case they are being written to)
  * `remove_remote_files_l#`

--- a/adcp.py
+++ b/adcp.py
@@ -15,7 +15,7 @@ class ADCP(sensor.Sensor):
     def __init__(
             self,
             data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA',
-            file_regex_l1=r"adcp_(\d{14})\.dat",
+            file_search_l1=r"adcp_(\d{14})\.dat",
             drop_recent_files_l1=1,
             remove_remote_files_l1=True,
             max_files_l1=20,
@@ -25,7 +25,7 @@ class ADCP(sensor.Sensor):
         # Init the Sensor() class: Unused levels are set to None.
         super(ADCP, self).__init__()
         self.data_dir = data_dir
-        self.file_regex_l1 = file_regex_l1
+        self.file_search_l1 = file_search_l1
         self.drop_recent_files_l1 = drop_recent_files_l1
         self.remove_remote_files_l1 = remove_remote_files_l1
         self.max_files_l1 = max_files_l1

--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ az_influx_pc = data['az_influx_pc']
 rsync_inbox = os.path.join(base_dir, 'Rsync_inbox')
 rsync_inbox_adcp = os.path.join(base_dir, 'Rsync_inbox_adcp')
 main_logfile = "log_munkholmen_ingest_"
+gas_logfile = "log_gasanalyser_ingest_"
 
 
 # Sync loggernet:

--- a/ctd.py
+++ b/ctd.py
@@ -16,7 +16,7 @@ class CTD(sensor.Sensor):
     def __init__(
             self,
             data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA',
-            file_regex_l0=r"ready_ctd_(\d{14})\.csv",
+            file_search_l0=r"ready_ctd_(\d{14})\.csv",
             drop_recent_files_l0=0,
             remove_remote_files_l0=True,
             max_files_l0=None,
@@ -25,7 +25,7 @@ class CTD(sensor.Sensor):
         # Init the Sensor() class: Unused vars/levels are set to None.
         super(CTD, self).__init__()
         self.data_dir = data_dir
-        self.file_regex_l0 = file_regex_l0
+        self.file_search_l0 = file_search_l0
         self.drop_recent_files_l0 = drop_recent_files_l0
         self.remove_remote_files_l0 = remove_remote_files_l0
         self.max_files_l0 = max_files_l0

--- a/documentation/InfluxDB_cheatsheet.md
+++ b/documentation/InfluxDB_cheatsheet.md
@@ -10,6 +10,7 @@
 ## Connect to InfluxDB using the commandline:
 
     $ influx
+    $ influx -username UNAME -password PASSWORD -precision rfc3339
 
 ## Basic commands from within the cl client:
 
@@ -33,7 +34,6 @@ Add a data point:
 
     INSERT meaurement_name,key=5 value=12
 
-
 Show measurements for name: meaurement_name:
 
     SELECT * FROM meaurement_name LIMIT 3
@@ -44,8 +44,9 @@ Drop meaurement_name measurements:
 
 Show field keys:
 
-    SHOW FIELD KEYS FROM "meaurement_name-A6"
-    
+    SHOW FIELD KEYS FROM "meaurement_name"
+    SHOW FIELD KEYS ON db_name FROM "meaurement_name"
+
 Get power records from measurement with tag and time range:
 
     SELECT "power" FROM "drilling" WHERE ("module_id"='rover') AND time >= now() - 9h
@@ -61,3 +62,9 @@ Drop all series for tag:
 Drop a datapoint need to happen by filtering on time:
 
     DELETE FROM "drilling" WHERE time > '2022-06-05 15:10:42' and time < '2022-06-07 03:20:42'
+
+Some user commands:
+
+    CREATE USER username WITH PASSWORD 'password'
+    GRANT READ ON database_name TO username
+    SHOW GRANTS FOR username

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -1,0 +1,85 @@
+import os
+import numpy as np
+import pandas as pd
+import seawater
+import xmltodict
+
+import sensor
+import config
+import util_db
+import util_file
+
+logger = util_file.init_logger(config.main_logfile, name='olmo.gasanalyser')
+
+
+class GasAnalyser(sensor.Sensor):
+    def __init__(
+            self,
+            data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA/gas',
+            recursive_file_search_l0=True,
+            file_search_l0='gga_????-??-??_f????.txt',
+            drop_recent_files_l0=0,
+            remove_remote_files_l0=False,  # True
+            max_files_l0=1,  # None
+            influx_clients=None):
+
+        # Init the Sensor() class: Unused vars/levels are set to None.
+        super(GasAnalyser, self).__init__()
+        self.data_dir = data_dir
+        self.recursive_file_search_l0 = recursive_file_search_l0
+        self.file_search_l0 = file_search_l0
+        self.drop_recent_files_l0 = drop_recent_files_l0
+        self.remove_remote_files_l0 = remove_remote_files_l0
+        self.max_files_l0 = max_files_l0
+        self.influx_clients = influx_clients
+
+    def ingest_l0(self, files):
+
+        for f in files:
+            print(f)
+            df_all = pd.read_csv(f, sep=',', skiprows=1)
+
+            for c in df_all.columns:
+                print("'" + c + "'")
+            # print(df_all.head())
+
+            time_col = '                     Time'
+            df_all = util_db.force_float_cols(df_all, not_float_cols=[time_col], error_to_nan=True)
+            df_all[time_col] = pd.to_datetime(df_all[time_col], format='  %d/%m/%Y %H:%M:%S.%f')
+            df_all = df_all.set_index(time_col).tz_localize('CET', ambiguous='infer').tz_convert('UTC')
+
+            print(df_all.head())
+
+            # tag_values = {'tag_sensor': 'ctd',
+            #               'tag_serial': '12345'
+            #               'tag_edge_device': 'munkholmen_topside_pi',
+            #               'tag_platform': 'munkholmen',
+            #               'tag_data_level': 'raw',
+            #               'tag_approved': 'no',
+            #               'tag_unit': 'none'}
+
+            # # ------------------------------------------------------------ #
+            # measurement_name = 'ctd_temperature_munkholmen'
+            # field_keys = {"Temperature": 'temperature'}
+            # tag_values['tag_unit'] = 'degrees_celcius'
+            # df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            # # util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # # ------------------------------------------------------------ #
+            # measurement_name = 'ctd_conductivity_munkholmen'
+            # field_keys = {"Conductivity": 'conductivity'}
+            # tag_values['tag_unit'] = 'siemens_per_metre'
+            # df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            # # util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # logger.info(f'File {f} ingested.')
+
+    def rsync_and_ingest(self):
+
+        files = self.rsync()
+        logger.info('ctd.rsync() finished.')
+
+        if files['l0'] is not None:
+            self.ingest_l0(files['l0'])
+
+        logger.info('ctd.rsync_and_ingest() finished.')

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -10,7 +10,6 @@ import util_file
 
 logger = util_file.init_logger(config.main_logfile, name='olmo.gasanalyser')
 
-# Test by running in one folder? How do you develop and not ingest actually
 
 class GasAnalyser(sensor.Sensor):
     def __init__(
@@ -103,7 +102,6 @@ class GasAnalyser(sensor.Sensor):
                               "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                # put return statement here
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -112,22 +110,18 @@ class GasAnalyser(sensor.Sensor):
                               "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_co2'
                 field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
                               "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)                
-
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
                 # From vizualisations, we see that there are values < 0 that are probably errors
                 # tag_approved_level will be changed to "no" from "none" as likely not passing filter
                 df.loc[df.co2_ppm < 0, 'tag_approved'] = "no"
-
-
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
-                #print(df.head())
-
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_ch4d'

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -20,12 +20,12 @@ class GasAnalyser(sensor.Sensor):
             file_search_l0='gga_????-??-??_f????.txt',
             drop_recent_files_l0=1,
             remove_remote_files_l0=False,
-            max_files_l0=1,
+            max_files_l0=None,
             recursive_file_search_l1=True,
             file_search_l1='gga_????-??-??_f????.txt.zip',
             drop_recent_files_l1=1,
             remove_remote_files_l1=False,
-            max_files_l1=1,
+            max_files_l1=None,
             influx_clients=None):
 
         # Init the Sensor() class: Unused vars/levels are set to None.
@@ -104,7 +104,7 @@ class GasAnalyser(sensor.Sensor):
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
                 # put return statement here
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_h2o'
@@ -119,14 +119,13 @@ class GasAnalyser(sensor.Sensor):
                               "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)                
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # From vizualisations, we see that there are values < 0 that are probably errors
                 # tag_approved_level will be changed to "no" from "none" as likely not passing filter
-                df.loc[df.co2_ppm < 0, 'tag_values'] = "no"
+                df.loc[df.co2_ppm < 0, 'tag_approved'] = "no"
 
 
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
                 #print(df.head())
 
 
@@ -136,7 +135,7 @@ class GasAnalyser(sensor.Sensor):
                               "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_co2d'
@@ -144,7 +143,7 @@ class GasAnalyser(sensor.Sensor):
                               "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_gasp'
@@ -152,7 +151,7 @@ class GasAnalyser(sensor.Sensor):
                               "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
                 tag_values['tag_unit'] = 'torr'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_gast'
@@ -160,7 +159,7 @@ class GasAnalyser(sensor.Sensor):
                               "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_ambt'
@@ -168,7 +167,7 @@ class GasAnalyser(sensor.Sensor):
                               "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_aux'
@@ -181,7 +180,7 @@ class GasAnalyser(sensor.Sensor):
                               "       MIU_DESC": util_db.format_str("       MIU_DESC")}
                 tag_values['tag_unit'] = 'none'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 logger.info(f'File {f} ingested.')
             except (ValueError, KeyError) as error:

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -185,6 +185,8 @@ class GasAnalyser(sensor.Sensor):
         if files['l0'] is not None:
             self.ingest_l0(files['l0'])
         if files['l1'] is not None:
-            self.ingest_l0(files['l1'])  # NOTE: we are sending l1 files to the l0 ingester here.
-# What does the above comment mean?
+            # NOTE: we are sending l1 files to the l0 ingester here.
+            # l0 is .txt files, l1 is .zip files. We will unzip within .ingest_l0.
+            self.ingest_l0(files['l1'])
+
         logger.info('ctd.rsync_and_ingest() finished.')

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -10,6 +10,7 @@ import util_file
 
 logger = util_file.init_logger(config.main_logfile, name='olmo.gasanalyser')
 
+# Test by running in one folder? How do you develop and not ingest actually
 
 class GasAnalyser(sensor.Sensor):
     def __init__(
@@ -19,12 +20,12 @@ class GasAnalyser(sensor.Sensor):
             file_search_l0='gga_????-??-??_f????.txt',
             drop_recent_files_l0=1,
             remove_remote_files_l0=False,
-            max_files_l0=None,
+            max_files_l0=1,
             recursive_file_search_l1=True,
             file_search_l1='gga_????-??-??_f????.txt.zip',
             drop_recent_files_l1=1,
             remove_remote_files_l1=False,
-            max_files_l1=None,
+            max_files_l1=1,
             influx_clients=None):
 
         # Init the Sensor() class: Unused vars/levels are set to None.
@@ -47,8 +48,8 @@ class GasAnalyser(sensor.Sensor):
         for f in files:
 
             # Special conditions:
-            # Note that the place we get the data from will continually fefil with data. So we will
-            # cotinually reingest data. This is not optimal.
+            # Note that the place we get the data from will continually refill with data. So we will
+            # continually reingest data. This is not optimal.
             #
             # If date is 2002-01-01: We should skip it.
             # If data is > 2022-09-01: We should label it as from the munkholmen buoy, otherwise its origin is unknown.
@@ -102,7 +103,8 @@ class GasAnalyser(sensor.Sensor):
                               "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # put return statement here
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_h2o'
@@ -110,15 +112,23 @@ class GasAnalyser(sensor.Sensor):
                               "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_co2'
                 field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
                               "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)                
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+                # From vizualisations, we see that there are values < 0 that are probably errors
+                # tag_approved_level will be changed to "no" from "none" as likely not passing filter
+                df.loc[df.co2_ppm < 0, 'tag_values'] = "no"
+
+
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #print(df.head())
+
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_ch4d'
@@ -126,7 +136,7 @@ class GasAnalyser(sensor.Sensor):
                               "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_co2d'
@@ -134,7 +144,7 @@ class GasAnalyser(sensor.Sensor):
                               "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_gasp'
@@ -142,7 +152,7 @@ class GasAnalyser(sensor.Sensor):
                               "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
                 tag_values['tag_unit'] = 'torr'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_gast'
@@ -150,7 +160,7 @@ class GasAnalyser(sensor.Sensor):
                               "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_ambt'
@@ -158,7 +168,7 @@ class GasAnalyser(sensor.Sensor):
                               "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
                 measurement_name = 'gasanalyser_aux'
@@ -171,7 +181,7 @@ class GasAnalyser(sensor.Sensor):
                               "       MIU_DESC": util_db.format_str("       MIU_DESC")}
                 tag_values['tag_unit'] = 'none'
                 df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                util_db.ingest_df(measurement_name, df, self.influx_clients)
+                #util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 logger.info(f'File {f} ingested.')
             except (ValueError, KeyError) as error:
@@ -186,5 +196,5 @@ class GasAnalyser(sensor.Sensor):
             self.ingest_l0(files['l0'])
         if files['l1'] is not None:
             self.ingest_l0(files['l1'])  # NOTE: we are sending l1 files to the l0 ingester here.
-
+# What does the above comment mean? 
         logger.info('ctd.rsync_and_ingest() finished.')

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -101,7 +101,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"      [CH4]_ppm": util_db.format_str("      [CH4]_ppm"),
                               "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -109,7 +109,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"      [H2O]_ppm": util_db.format_str("      [H2O]_ppm"),
                               "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -117,10 +117,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
                               "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-                # From vizualisations, we see that there are values < 0 that are probably errors
-                # tag_approved_level will be changed to "no" from "none" as likely not passing filter
-                df.loc[df.co2_ppm < 0, 'tag_approved'] = "no"
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -128,7 +125,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"     [CH4]d_ppm": util_db.format_str("     [CH4]d_ppm"),
                               "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -136,7 +133,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"     [CO2]d_ppm": util_db.format_str("     [CO2]d_ppm"),
                               "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
                 tag_values['tag_unit'] = 'ppm'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -144,7 +141,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"      GasP_torr": util_db.format_str("      GasP_torr"),
                               "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
                 tag_values['tag_unit'] = 'torr'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -152,7 +149,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"         GasT_C": util_db.format_str("         GasT_C"),
                               "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -160,7 +157,7 @@ class GasAnalyser(sensor.Sensor):
                 field_keys = {"         AmbT_C": util_db.format_str("         AmbT_C"),
                               "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
                 tag_values['tag_unit'] = 'degrees_celcius'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 # ------------------------------------------------------------ #
@@ -173,7 +170,7 @@ class GasAnalyser(sensor.Sensor):
                               "      MIU_VALVE": util_db.format_str("      MIU_VALVE"),
                               "       MIU_DESC": util_db.format_str("       MIU_DESC")}
                 tag_values['tag_unit'] = 'none'
-                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=True)
                 util_db.ingest_df(measurement_name, df, self.influx_clients)
 
                 logger.info(f'File {f} ingested.')
@@ -189,5 +186,5 @@ class GasAnalyser(sensor.Sensor):
             self.ingest_l0(files['l0'])
         if files['l1'] is not None:
             self.ingest_l0(files['l1'])  # NOTE: we are sending l1 files to the l0 ingester here.
-# What does the above comment mean? 
+# What does the above comment mean?
         logger.info('ctd.rsync_and_ingest() finished.')

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 import pandas as pd
 import zipfile
 
@@ -16,14 +17,14 @@ class GasAnalyser(sensor.Sensor):
             data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA/gas',
             recursive_file_search_l0=True,
             file_search_l0='gga_????-??-??_f????.txt',
-            drop_recent_files_l0=0,
+            drop_recent_files_l0=1,
             remove_remote_files_l0=False,
-            max_files_l0=1,  # None
+            max_files_l0=None,
             recursive_file_search_l1=True,
             file_search_l1='gga_????-??-??_f????.txt.zip',
-            drop_recent_files_l1=0,
+            drop_recent_files_l1=1,
             remove_remote_files_l1=False,
-            max_files_l1=1,  # None
+            max_files_l1=None,
             influx_clients=None):
 
         # Init the Sensor() class: Unused vars/levels are set to None.
@@ -45,6 +46,13 @@ class GasAnalyser(sensor.Sensor):
 
         for f in files:
 
+            # Special conditions:
+            # Note that the place we get the data from will continually fefil with data. So we will
+            # cotinually reingest data. This is not optimal.
+            #
+            # If date is 2002-01-01: We should skip it.
+            # If data is > 2022-09-01: We should label it as from the munkholmen buoy, otherwise its origin is unknown.
+
             # Unzip any zip files:
             file_type_tag = 'txt'
             if f[-4:] == '.zip':
@@ -61,101 +69,113 @@ class GasAnalyser(sensor.Sensor):
                     f_handle.seek(cut_line)
                     f_handle.truncate()
 
-            df_all = pd.read_csv(f, sep=',', skiprows=1)
+            # Will put this all into a try/except clause, since many files have odd formats I can't
+            # be bothered dealing with (strange timestamps, not all cols)
+            try:
+                from_munkholmen = False
+                if f[-20:-10] in ['2002-01-01']:
+                    # print(f"Skipping file: {f}")
+                    continue
+                elif datetime.datetime.strptime(f[-20:-10], '%Y-%m-%d') > datetime.datetime(2022, 8, 31, 23, 59, 00):
+                    from_munkholmen = True
+                    # print(f"File {f} deemed from munkholmen.")
 
-            time_col = '                     Time'
-            df_all = util_db.force_float_cols(df_all, not_float_cols=[time_col], error_to_nan=True)
-            df_all[time_col] = pd.to_datetime(df_all[time_col], format='  %d/%m/%Y %H:%M:%S.%f')
-            df_all = df_all.set_index(time_col).tz_localize('CET', ambiguous='infer').tz_convert('UTC')
+                df_all = pd.read_csv(f, sep=',', skiprows=1)
 
-            # From Sep 1 edge_device and platform are moved to munkholmen, none before.
-            tag_values = {'tag_sensor': 'LGR-UGGA',
-                          'tag_edge_device': 'none',
-                          'tag_platform': 'none',
-                          # 'tag_edge_device': 'munkholmen_topside_pi',
-                          # 'tag_platform': 'munkholmen',
-                          'tag_data_level': 'raw',
-                          'tag_approved': 'none',
-                          'tag_file_type': file_type_tag}
+                time_col = '                     Time'
+                df_all = util_db.force_float_cols(df_all, not_float_cols=[time_col], error_to_nan=True)
+                df_all[time_col] = pd.to_datetime(df_all[time_col], format='  %d/%m/%Y %H:%M:%S.%f')
+                df_all = df_all.set_index(time_col).tz_localize('CET', ambiguous='infer').tz_convert('UTC')
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_ch4'
-            field_keys = {"      [CH4]_ppm": util_db.format_str("      [CH4]_ppm"),
-                          "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
-            tag_values['tag_unit'] = 'ppm'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                ted = 'munkholmen_topside_pi' if from_munkholmen else 'none'
+                tp = 'munkholmen' if from_munkholmen else 'none'
+                tag_values = {'tag_sensor': 'LGR-UGGA',
+                              'tag_edge_device': ted,
+                              'tag_platform': tp,
+                              'tag_data_level': 'raw',
+                              'tag_approved': 'none',
+                              'tag_file_type': file_type_tag}
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_h2o'
-            field_keys = {"      [H2O]_ppm": util_db.format_str("      [H2O]_ppm"),
-                          "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
-            tag_values['tag_unit'] = 'ppm'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_ch4'
+                field_keys = {"      [CH4]_ppm": util_db.format_str("      [CH4]_ppm"),
+                              "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
+                tag_values['tag_unit'] = 'ppm'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_co2'
-            field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
-                          "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
-            tag_values['tag_unit'] = 'ppm'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_h2o'
+                field_keys = {"      [H2O]_ppm": util_db.format_str("      [H2O]_ppm"),
+                              "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
+                tag_values['tag_unit'] = 'ppm'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_ch4d'
-            field_keys = {"     [CH4]d_ppm": util_db.format_str("     [CH4]d_ppm"),
-                          "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
-            tag_values['tag_unit'] = 'ppm'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_co2'
+                field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
+                              "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
+                tag_values['tag_unit'] = 'ppm'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_co2d'
-            field_keys = {"     [CO2]d_ppm": util_db.format_str("     [CO2]d_ppm"),
-                          "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
-            tag_values['tag_unit'] = 'ppm'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_ch4d'
+                field_keys = {"     [CH4]d_ppm": util_db.format_str("     [CH4]d_ppm"),
+                              "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
+                tag_values['tag_unit'] = 'ppm'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_gasp'
-            field_keys = {"      GasP_torr": util_db.format_str("      GasP_torr"),
-                          "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
-            tag_values['tag_unit'] = 'torr'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_co2d'
+                field_keys = {"     [CO2]d_ppm": util_db.format_str("     [CO2]d_ppm"),
+                              "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
+                tag_values['tag_unit'] = 'ppm'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_gast'
-            field_keys = {"         GasT_C": util_db.format_str("         GasT_C"),
-                          "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
-            tag_values['tag_unit'] = 'degrees_celcius'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_gasp'
+                field_keys = {"      GasP_torr": util_db.format_str("      GasP_torr"),
+                              "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
+                tag_values['tag_unit'] = 'torr'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_ambt'
-            field_keys = {"         AmbT_C": util_db.format_str("         AmbT_C"),
-                          "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
-            tag_values['tag_unit'] = 'degrees_celcius'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_gast'
+                field_keys = {"         GasT_C": util_db.format_str("         GasT_C"),
+                              "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
+                tag_values['tag_unit'] = 'degrees_celcius'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # ------------------------------------------------------------ #
-            measurement_name = 'gasanalyser_aux'
-            field_keys = {"         RD0_us": util_db.format_str("         RD0_us"),
-                          "      RD0_us_sd": util_db.format_str("      RD0_us_sd"),
-                          "         RD1_us": util_db.format_str("         RD1_us"),
-                          "      RD1_us_sd": util_db.format_str("      RD1_us_sd"),
-                          "       Fit_Flag": util_db.format_str("       Fit_Flag"),
-                          "      MIU_VALVE": util_db.format_str("      MIU_VALVE"),
-                          "       MIU_DESC": util_db.format_str("       MIU_DESC")}
-            tag_values['tag_unit'] = 'none'
-            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            util_db.ingest_df(measurement_name, df, self.influx_clients)
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_ambt'
+                field_keys = {"         AmbT_C": util_db.format_str("         AmbT_C"),
+                              "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
+                tag_values['tag_unit'] = 'degrees_celcius'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            logger.info(f'File {f} ingested.')
+                # ------------------------------------------------------------ #
+                measurement_name = 'gasanalyser_aux'
+                field_keys = {"         RD0_us": util_db.format_str("         RD0_us"),
+                              "      RD0_us_sd": util_db.format_str("      RD0_us_sd"),
+                              "         RD1_us": util_db.format_str("         RD1_us"),
+                              "      RD1_us_sd": util_db.format_str("      RD1_us_sd"),
+                              "       Fit_Flag": util_db.format_str("       Fit_Flag"),
+                              "      MIU_VALVE": util_db.format_str("      MIU_VALVE"),
+                              "       MIU_DESC": util_db.format_str("       MIU_DESC")}
+                tag_values['tag_unit'] = 'none'
+                df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+                util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+                logger.info(f'File {f} ingested.')
+            except (ValueError, KeyError) as error:
+                logger.info(f"Failed on file: {f}\nError: {error}")
 
     def rsync_and_ingest(self):
 
@@ -163,10 +183,8 @@ class GasAnalyser(sensor.Sensor):
         logger.info('ctd.rsync() finished.')
 
         if files['l0'] is not None:
-            print('l0 files:', files['l0'])
             self.ingest_l0(files['l0'])
         if files['l1'] is not None:
-            print('l1 files:', files['l1'])
             self.ingest_l0(files['l1'])  # NOTE: we are sending l1 files to the l0 ingester here.
 
         logger.info('ctd.rsync_and_ingest() finished.')

--- a/gas_analyser.py
+++ b/gas_analyser.py
@@ -1,8 +1,6 @@
 import os
-import numpy as np
 import pandas as pd
-import seawater
-import xmltodict
+import zipfile
 
 import sensor
 import config
@@ -19,8 +17,13 @@ class GasAnalyser(sensor.Sensor):
             recursive_file_search_l0=True,
             file_search_l0='gga_????-??-??_f????.txt',
             drop_recent_files_l0=0,
-            remove_remote_files_l0=False,  # True
+            remove_remote_files_l0=False,
             max_files_l0=1,  # None
+            recursive_file_search_l1=True,
+            file_search_l1='gga_????-??-??_f????.txt.zip',
+            drop_recent_files_l1=0,
+            remove_remote_files_l1=False,
+            max_files_l1=1,  # None
             influx_clients=None):
 
         # Init the Sensor() class: Unused vars/levels are set to None.
@@ -31,48 +34,128 @@ class GasAnalyser(sensor.Sensor):
         self.drop_recent_files_l0 = drop_recent_files_l0
         self.remove_remote_files_l0 = remove_remote_files_l0
         self.max_files_l0 = max_files_l0
+        self.recursive_file_search_l1 = recursive_file_search_l1
+        self.file_search_l1 = file_search_l1
+        self.drop_recent_files_l1 = drop_recent_files_l1
+        self.remove_remote_files_l1 = remove_remote_files_l1
+        self.max_files_l1 = max_files_l1
         self.influx_clients = influx_clients
 
     def ingest_l0(self, files):
 
         for f in files:
-            print(f)
-            df_all = pd.read_csv(f, sep=',', skiprows=1)
 
-            for c in df_all.columns:
-                print("'" + c + "'")
-            # print(df_all.head())
+            # Unzip any zip files:
+            file_type_tag = 'txt'
+            if f[-4:] == '.zip':
+                file_type_tag = 'zip'
+                with zipfile.ZipFile(f, "r") as zip_ref:
+                    zip_ref.extractall(os.path.dirname(f))
+                f = f[:-4]
+                # These zip files have a "PGP message" at the end, which must be removed.
+                with open(f, "r+") as f_handle:
+                    for num, line in enumerate(f_handle):
+                        if '-----BEGIN PGP MESSAGE-----' in line:
+                            cut_line = num
+                            break
+                    f_handle.seek(cut_line)
+                    f_handle.truncate()
+
+            df_all = pd.read_csv(f, sep=',', skiprows=1)
 
             time_col = '                     Time'
             df_all = util_db.force_float_cols(df_all, not_float_cols=[time_col], error_to_nan=True)
             df_all[time_col] = pd.to_datetime(df_all[time_col], format='  %d/%m/%Y %H:%M:%S.%f')
             df_all = df_all.set_index(time_col).tz_localize('CET', ambiguous='infer').tz_convert('UTC')
 
-            print(df_all.head())
+            # From Sep 1 edge_device and platform are moved to munkholmen, none before.
+            tag_values = {'tag_sensor': 'LGR-UGGA',
+                          'tag_edge_device': 'none',
+                          'tag_platform': 'none',
+                          # 'tag_edge_device': 'munkholmen_topside_pi',
+                          # 'tag_platform': 'munkholmen',
+                          'tag_data_level': 'raw',
+                          'tag_approved': 'none',
+                          'tag_file_type': file_type_tag}
 
-            # tag_values = {'tag_sensor': 'ctd',
-            #               'tag_serial': '12345'
-            #               'tag_edge_device': 'munkholmen_topside_pi',
-            #               'tag_platform': 'munkholmen',
-            #               'tag_data_level': 'raw',
-            #               'tag_approved': 'no',
-            #               'tag_unit': 'none'}
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_ch4'
+            field_keys = {"      [CH4]_ppm": util_db.format_str("      [CH4]_ppm"),
+                          "   [CH4]_ppm_sd": util_db.format_str("   [CH4]_ppm_sd")}
+            tag_values['tag_unit'] = 'ppm'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # # ------------------------------------------------------------ #
-            # measurement_name = 'ctd_temperature_munkholmen'
-            # field_keys = {"Temperature": 'temperature'}
-            # tag_values['tag_unit'] = 'degrees_celcius'
-            # df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            # # util_db.ingest_df(measurement_name, df, self.influx_clients)
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_h2o'
+            field_keys = {"      [H2O]_ppm": util_db.format_str("      [H2O]_ppm"),
+                          "   [H2O]_ppm_sd": util_db.format_str("   [H2O]_ppm_sd")}
+            tag_values['tag_unit'] = 'ppm'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # # ------------------------------------------------------------ #
-            # measurement_name = 'ctd_conductivity_munkholmen'
-            # field_keys = {"Conductivity": 'conductivity'}
-            # tag_values['tag_unit'] = 'siemens_per_metre'
-            # df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
-            # # util_db.ingest_df(measurement_name, df, self.influx_clients)
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_co2'
+            field_keys = {"      [CO2]_ppm": util_db.format_str("      [CO2]_ppm"),
+                          "   [CO2]_ppm_sd": util_db.format_str("   [CO2]_ppm_sd")}
+            tag_values['tag_unit'] = 'ppm'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
 
-            # logger.info(f'File {f} ingested.')
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_ch4d'
+            field_keys = {"     [CH4]d_ppm": util_db.format_str("     [CH4]d_ppm"),
+                          "  [CH4]d_ppm_sd": util_db.format_str("  [CH4]d_ppm_sd")}
+            tag_values['tag_unit'] = 'ppm'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_co2d'
+            field_keys = {"     [CO2]d_ppm": util_db.format_str("     [CO2]d_ppm"),
+                          "  [CO2]d_ppm_sd": util_db.format_str("  [CO2]d_ppm_sd")}
+            tag_values['tag_unit'] = 'ppm'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_gasp'
+            field_keys = {"      GasP_torr": util_db.format_str("      GasP_torr"),
+                          "   GasP_torr_sd": util_db.format_str("   GasP_torr_sd")}
+            tag_values['tag_unit'] = 'torr'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_gast'
+            field_keys = {"         GasT_C": util_db.format_str("         GasT_C"),
+                          "      GasT_C_sd": util_db.format_str("      GasT_C_sd")}
+            tag_values['tag_unit'] = 'degrees_celcius'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_ambt'
+            field_keys = {"         AmbT_C": util_db.format_str("         AmbT_C"),
+                          "      AmbT_C_sd": util_db.format_str("      AmbT_C_sd")}
+            tag_values['tag_unit'] = 'degrees_celcius'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            # ------------------------------------------------------------ #
+            measurement_name = 'gasanalyser_aux'
+            field_keys = {"         RD0_us": util_db.format_str("         RD0_us"),
+                          "      RD0_us_sd": util_db.format_str("      RD0_us_sd"),
+                          "         RD1_us": util_db.format_str("         RD1_us"),
+                          "      RD1_us_sd": util_db.format_str("      RD1_us_sd"),
+                          "       Fit_Flag": util_db.format_str("       Fit_Flag"),
+                          "      MIU_VALVE": util_db.format_str("      MIU_VALVE"),
+                          "       MIU_DESC": util_db.format_str("       MIU_DESC")}
+            tag_values['tag_unit'] = 'none'
+            df = util_db.filter_and_tag_df(df_all, field_keys, tag_values)
+            util_db.ingest_df(measurement_name, df, self.influx_clients)
+
+            logger.info(f'File {f} ingested.')
 
     def rsync_and_ingest(self):
 
@@ -80,6 +163,10 @@ class GasAnalyser(sensor.Sensor):
         logger.info('ctd.rsync() finished.')
 
         if files['l0'] is not None:
+            print('l0 files:', files['l0'])
             self.ingest_l0(files['l0'])
+        if files['l1'] is not None:
+            print('l1 files:', files['l1'])
+            self.ingest_l0(files['l1'])  # NOTE: we are sending l1 files to the l0 ingester here.
 
         logger.info('ctd.rsync_and_ingest() finished.')

--- a/ingest_gasanalyser.py
+++ b/ingest_gasanalyser.py
@@ -24,15 +24,6 @@ def main():
     gas = GasAnalyser(influx_clients=methane_client)
     gas.rsync_and_ingest()
 
-    # From vizualisations, we see that there are values < 0 that are probably errors
-    # tag_approved_level will be changed to "no" from "none" as likely not passing filter
-    print(gas)
-
-# to ask will: 
-# where/how to dev?
-# 1) how to edit dfs?
-# 2)  
-
 
 if __name__ == "__main__":
     main()

--- a/ingest_gasanalyser.py
+++ b/ingest_gasanalyser.py
@@ -1,0 +1,29 @@
+import os
+from datetime import datetime
+from influxdb import InfluxDBClient
+
+import config
+import util_file
+from gas_analyser import GasAnalyser
+
+
+def main():
+
+    print("Starting running ingest_gasanalyser.py at "
+          + datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+
+    logger = util_file.init_logger(config.main_logfile, name='ingest_gasanalyser')
+    logger.info("\n\n------ Starting sync/ingest.")
+
+    logger.info("Fetching the influxdb clients.")
+    admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
+    methane_client = [
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_closed'),
+    ]
+
+    gas = GasAnalyser(influx_clients=methane_client)
+    gas.rsync_and_ingest()
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest_gasanalyser.py
+++ b/ingest_gasanalyser.py
@@ -18,7 +18,7 @@ def main():
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
     methane_client = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_test_will'),
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_private'),
     ]
 
     gas = GasAnalyser(influx_clients=methane_client)

--- a/ingest_gasanalyser.py
+++ b/ingest_gasanalyser.py
@@ -12,13 +12,13 @@ def main():
     print("Starting running ingest_gasanalyser.py at "
           + datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
-    logger = util_file.init_logger(config.main_logfile, name='ingest_gasanalyser')
+    logger = util_file.init_logger(config.gas_logfile, name='ingest_gasanalyser')
     logger.info("\n\n------ Starting sync/ingest.")
 
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
     methane_client = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_test_lara'),
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_test_will'),
     ]
 
     gas = GasAnalyser(influx_clients=methane_client)

--- a/ingest_gasanalyser.py
+++ b/ingest_gasanalyser.py
@@ -18,11 +18,20 @@ def main():
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
     methane_client = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_closed'),
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_test_lara'),
     ]
 
     gas = GasAnalyser(influx_clients=methane_client)
     gas.rsync_and_ingest()
+
+    # From vizualisations, we see that there are values < 0 that are probably errors
+    # tag_approved_level will be changed to "no" from "none" as likely not passing filter
+    print(gas)
+
+# to ask will: 
+# where/how to dev?
+# 1) how to edit dfs?
+# 2)  
 
 
 if __name__ == "__main__":

--- a/ingest_munkholmen.py
+++ b/ingest_munkholmen.py
@@ -5,6 +5,7 @@ from influxdb import InfluxDBClient
 import config
 import util_file
 from ctd import CTD
+from gas_analyser import GasAnalyser
 # from adcp import ADCP
 # from lisst_200 import Lisst_200
 
@@ -20,12 +21,16 @@ def main():
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
     clients = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'oceanlab'),
-        InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+        # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
     ]
 
-    ctd = CTD(influx_clients=clients)
-    ctd.rsync_and_ingest()
+    # ctd = CTD(influx_clients=clients)
+    # ctd.rsync_and_ingest()
+
+    print('loading analyser class:')
+    gas = GasAnalyser(influx_clients=clients)
+    gas.rsync_and_ingest()
 
     # lisst = Lisst_200(influx_clients=clients)
     # lisst.rsync_and_ingest()

--- a/ingest_munkholmen.py
+++ b/ingest_munkholmen.py
@@ -4,7 +4,7 @@ from influxdb import InfluxDBClient
 
 import config
 import util_file
-from ctd import CTD
+# from ctd import CTD
 from gas_analyser import GasAnalyser
 # from adcp import ADCP
 # from lisst_200 import Lisst_200
@@ -20,19 +20,20 @@ def main():
 
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
-    clients = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'test'),
-        # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+    # open_clients = [
+    #     InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+    #     # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+    # ]
+    methane_client = [
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_closed'),
     ]
-
-    # ctd = CTD(influx_clients=clients)
+    # ctd = CTD(influx_clients=open_clients)
     # ctd.rsync_and_ingest()
 
-    print('loading analyser class:')
-    gas = GasAnalyser(influx_clients=clients)
+    gas = GasAnalyser(influx_clients=methane_client)
     gas.rsync_and_ingest()
 
-    # lisst = Lisst_200(influx_clients=clients)
+    # lisst = Lisst_200(influx_clients=open_clients)
     # lisst.rsync_and_ingest()
 
     # adcp = ADCP()

--- a/ingest_munkholmen.py
+++ b/ingest_munkholmen.py
@@ -4,8 +4,8 @@ from influxdb import InfluxDBClient
 
 import config
 import util_file
-# from ctd import CTD
-from gas_analyser import GasAnalyser
+from ctd import CTD
+# from gas_analyser import GasAnalyser
 # from adcp import ADCP
 # from lisst_200 import Lisst_200
 
@@ -20,18 +20,13 @@ def main():
 
     logger.info("Fetching the influxdb clients.")
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
-    # open_clients = [
-    #     InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'test'),
-    #     # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
-    # ]
-    methane_client = [
-        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'methane_closed'),
+    open_clients = [
+        InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'oceanlab'),
+        InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
     ]
-    # ctd = CTD(influx_clients=open_clients)
-    # ctd.rsync_and_ingest()
 
-    gas = GasAnalyser(influx_clients=methane_client)
-    gas.rsync_and_ingest()
+    ctd = CTD(influx_clients=open_clients)
+    ctd.rsync_and_ingest()
 
     # lisst = Lisst_200(influx_clients=open_clients)
     # lisst.rsync_and_ingest()

--- a/ingest_munkholmen_pi_status.py
+++ b/ingest_munkholmen_pi_status.py
@@ -19,7 +19,7 @@ def main():
     admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
     clients = [
         InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'oceanlab'),
-        InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
+        # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
     ]
 
     pi_status = Munkholmen_Pi(influx_clients=clients)

--- a/lisst_200.py
+++ b/lisst_200.py
@@ -16,12 +16,12 @@ class Lisst_200(sensor.Sensor):
     def __init__(
             self,
             data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA',
-            file_regex_l0=r"lisst_L(\d{7})\.RBN",
+            file_search_l0=r"lisst_L(\d{7})\.RBN",
             drop_recent_files_l0=0,
             remove_remote_files_l0=True,
             max_files_l0=10,
             measurement_name_l0='munk_lisst-200_l0',
-            file_regex_l1=r"ready_lisst_I(\d{7})\.CSV",
+            file_search_l1=r"ready_lisst_I(\d{7})\.CSV",
             drop_recent_files_l1=0,
             remove_remote_files_l1=True,
             max_files_l1=None,
@@ -31,12 +31,12 @@ class Lisst_200(sensor.Sensor):
         # Init the Sensor() class: Unused vars/levels are set to None.
         super(Lisst_200, self).__init__()
         self.data_dir = data_dir
-        self.file_regex_l0 = file_regex_l0
+        self.file_search_l0 = file_search_l0
         self.drop_recent_files_l0 = drop_recent_files_l0
         self.remove_remote_files_l0 = remove_remote_files_l0
         self.max_files_l0 = max_files_l0
         self.measurement_name_l0 = measurement_name_l0
-        self.file_regex_l1 = file_regex_l1
+        self.file_search_l1 = file_search_l1
         self.drop_recent_files_l1 = drop_recent_files_l1
         self.remove_remote_files_l1 = remove_remote_files_l1
         self.max_files_l1 = max_files_l1

--- a/munkholmen_pi_status.py
+++ b/munkholmen_pi_status.py
@@ -12,7 +12,7 @@ class Munkholmen_Pi(sensor.Sensor):
     def __init__(
             self,
             data_dir=f'/home/{config.munkholmen_user}/olmo/munkholmen/DATA',
-            file_regex_l0=r"status.csv",
+            file_search_l0=r"status.csv",
             drop_recent_files_l0=0,
             remove_remote_files_l0=False,
             max_files_l0=None,
@@ -21,7 +21,7 @@ class Munkholmen_Pi(sensor.Sensor):
         # Init the Sensor() class: Unused vars/levels are set to None.
         super(Munkholmen_Pi, self).__init__()
         self.data_dir = data_dir
-        self.file_regex_l0 = file_regex_l0
+        self.file_search_l0 = file_search_l0
         self.drop_recent_files_l0 = drop_recent_files_l0
         self.remove_remote_files_l0 = remove_remote_files_l0
         self.max_files_l0 = max_files_l0

--- a/scripts/postprocessing/copy_measurement.py
+++ b/scripts/postprocessing/copy_measurement.py
@@ -14,21 +14,18 @@ Takes data from a measurement in one DB, and puts that into another.
 
 # Databases:
 admin_user, admin_pwd = util_file.get_user_pwd(os.path.join(config.secrets_dir, 'influx_admin_credentials'))
-read_client = InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'example')
+read_client = InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'test')
 write_clients = [
     InfluxDBClient(config.az_influx_pc, 8086, admin_user, admin_pwd, 'oceanlab'),
     # InfluxDBClient(config.sintef_influx_pc, 8086, admin_user, admin_pwd, 'test'),
 ]
 
 # Measurements to be copied:
-measurement = 'ctd_correctsbe63_munkholmen'
-# measurements = [
-#     'ctd_correctsbe63_munkholmen',
-# ]
+measurement = 'pi_status_munkholmen'
 
 # Time period:
-start_time = '2022-06-01T00:00:00Z'
-end_time = '2022-07-10T08:00:00Z'
+start_time = '2022-08-25T12:00:00Z'
+end_time = '2022-10-20T12:00:00Z'
 
 
 def main():
@@ -38,9 +35,10 @@ def main():
 
     periods = util_db.break_down_time_period(start_time, end_time)
 
-    # Get ctd object and load the calibration file.
-    ctd = CTD()
-    ctd.load_calibration()
+    # # ---- May need some custom code here:
+    # # Get ctd object and load the calibration file.
+    # ctd = CTD()
+    # ctd.load_calibration()
 
     for p in periods:
         timeslice = f"time > '{p[0]}' AND time < '{p[1]}'"
@@ -50,11 +48,13 @@ def main():
         df = util_db.query_influxdb(read_client, measurement, timeslice)
         # The result doesn't have 'tag_' on tag cols, and the index isn't time yet.
         df = util_db.retag_tag_cols(df, util_db.get_tag_keys(read_client, measurement))
+        # The below line should be checked, it might not be needed in your case.
+        df = util_db.force_float_cols(df, not_float_cols=['time'], error_to_nan=True)  # Should be done after the above line
         df = df.set_index('time').tz_convert('UTC')  # Should be in correct TZ as comes from DB
 
         # =================== Upload to clinents:
         util_db.ingest_df(measurement, df, write_clients)
-        print(' ... Data written :)')
+        print(f' ... {df.shape[0]} pts written :)')
 
     print("Finished all at "
           + datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))

--- a/sensor.py
+++ b/sensor.py
@@ -103,6 +103,7 @@ class Sensor:
             # Remove the 'self.data_dir' from the file path, so consistet with below
             for i, f in enumerate(files):
                 files[i] = f[len(self.data_dir) + 1:]
+            files.sort()
         else:
             ls_out, ls_err = util_file.ls_remote(
                 config.munkholmen_user, config.munkholmen_pc,

--- a/util_db.py
+++ b/util_db.py
@@ -72,7 +72,8 @@ def force_float_cols(df, float_cols=None, not_float_cols=None, error_to_nan=Fals
         for col in df.columns:
             if col in float_cols:
                 if error_to_nan:
-                    df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999)
+                    df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999.0)
+                    df[col] = df[col].astype(np.float64)
                 else:
                     df[col] = df[col].astype(np.float64)
         return df
@@ -81,7 +82,8 @@ def force_float_cols(df, float_cols=None, not_float_cols=None, error_to_nan=Fals
         for col in df.columns:
             if col not in not_float_cols:
                 if error_to_nan:
-                    df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999)
+                    df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999.0)
+                    df[col] = df[col].astype(np.float64)
                 else:
                     df[col] = df[col].astype(np.float64)
         return df

--- a/util_db.py
+++ b/util_db.py
@@ -128,7 +128,7 @@ def add_tags(df, tag_values):
     return df
 
 
-def filter_and_tag_df(df_all, field_keys, tag_values):
+def filter_and_tag_df(df_all, field_keys, tag_values, disapprove_nans=False):
     '''
     Given a df with a large set of data returns a df with only the data
     from 'field_keys' and tagged with 'tag_values'
@@ -141,6 +141,9 @@ def filter_and_tag_df(df_all, field_keys, tag_values):
     tag_values : dict
         Should be key value pairs of tag names and tag values.
         It is assume all rows in the df have the same tag values.
+    disapprove_nan : bool
+        Does nothing if tag_approved not in df.
+        Will set 'tag_approved' to 'no' if any field key has value -7999
 
     Returns
     -------
@@ -149,6 +152,10 @@ def filter_and_tag_df(df_all, field_keys, tag_values):
     df = df_all.loc[:, [k for k in field_keys.keys()]]
     df = df.rename(columns=field_keys)
     df = add_tags(df, tag_values)
+    if disapprove_nans:
+        if 'tag_approved' in tag_values:
+            for field in field_keys.values():
+                df.loc[df[field] == -7999., 'tag_approved'] = 'no'
     return df
 
 

--- a/util_db.py
+++ b/util_db.py
@@ -1,5 +1,6 @@
 import logging
 import datetime
+import re
 import numpy as np
 import pandas as pd
 
@@ -304,3 +305,22 @@ def break_down_time_period(start_time, end_time):
             end_time_.strftime('%Y-%m-%dT%H:%M:%SZ')))
 
     return periods
+
+
+def format_str(string):
+    '''
+    Formats a string such that it conforms to Williams conventions for
+    db names (lower case, no special chars except '_').
+
+    Parameters
+    ----------
+    string : str
+
+    Returns
+    -------
+    str
+    '''
+    string.replace('-', '_')
+    string = re.sub('[^A-Za-z0-9_]+', '', string)  # Remove special chars (except '_')
+    string = re.sub('\s+', '', string)
+    return string.lower()

--- a/util_db.py
+++ b/util_db.py
@@ -70,7 +70,7 @@ def force_float_cols(df, float_cols=None, not_float_cols=None, error_to_nan=Fals
     if float_cols is not None:
         assert not_float_cols is None, "Only one col list should be given"
         for col in df.columns:
-            if col in float_cols:
+            if (col in float_cols) and (col[:4] != 'tag_'):
                 if error_to_nan:
                     df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999.0)
                     df[col] = df[col].astype(np.float64)
@@ -80,7 +80,7 @@ def force_float_cols(df, float_cols=None, not_float_cols=None, error_to_nan=Fals
     elif not_float_cols is not None:
         assert float_cols is None, "Only one col list should be given"
         for col in df.columns:
-            if col not in not_float_cols:
+            if (col not in not_float_cols) and (col[:4] != 'tag_'):
                 if error_to_nan:
                     df[col] = df[col].apply(pd.to_numeric, errors='coerce').fillna(-7999.0)
                     df[col] = df[col].astype(np.float64)

--- a/util_file.py
+++ b/util_file.py
@@ -71,7 +71,7 @@ def remove_timestring(filepath):
         return base_name
 
 
-def ls_remote(user, machine, directory, port=22, custom_search=None):
+def ls_remote(user, machine, directory, port=22):
     '''
     Perform 'ls' over ssh onto linux machine.
 

--- a/util_file.py
+++ b/util_file.py
@@ -101,6 +101,7 @@ def ls_remote(user, machine, directory, port=22, custom_search=None):
 def find_remote(user, machine, directory, serach, port=22):
     '''
     Perform 'find {directory} -name '{custom_search}'"' over ssh onto linux machine.
+    Note this returns the full file path, not relative to 'directory'.
 
     Parameters
     ----------

--- a/util_file.py
+++ b/util_file.py
@@ -71,9 +71,9 @@ def remove_timestring(filepath):
         return base_name
 
 
-def ls_remote(user, machine, directory, port=22):
+def ls_remote(user, machine, directory, port=22, custom_search=None):
     '''
-    Perform 'ls' over ssh onto linux machine. Uses ssh.
+    Perform 'ls' over ssh onto linux machine.
 
     Parameters
     ----------
@@ -93,8 +93,37 @@ def ls_remote(user, machine, directory, port=22):
 
     command = f"ls {directory}"
     stdin, stdout, stderr = ssh.exec_command(command)
+    stdout = stdout.read().decode(errors='ignore'), stderr.read().decode(errors='ignore')
 
-    return stdout.read().decode(errors='ignore'), stderr.read().decode(errors='ignore')
+    return stdout
+
+
+def find_remote(user, machine, directory, serach, port=22):
+    '''
+    Perform 'find {directory} -name '{custom_search}'"' over ssh onto linux machine.
+
+    Parameters
+    ----------
+    user : str
+    machine : str
+        IP address of the maching you will connect to.
+    directory : str
+    search : str
+    port : int, default 22
+
+    Returns
+    -------
+    str
+    '''
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(machine, username=user, port=port)
+
+    command = f"find {directory} -name '{serach}'"
+    stdin, stdout, stderr = ssh.exec_command(command)
+    stdout = stdout.read().decode(errors='ignore'), stderr.read().decode(errors='ignore')
+
+    return stdout
 
 
 def get_user_pwd(file):

--- a/util_file.py
+++ b/util_file.py
@@ -98,9 +98,9 @@ def ls_remote(user, machine, directory, port=22, custom_search=None):
     return stdout
 
 
-def find_remote(user, machine, directory, serach, port=22):
+def find_remote(user, machine, directory, search, port=22):
     '''
-    Perform 'find {directory} -name '{custom_search}'"' over ssh onto linux machine.
+    Perform 'find {directory} -name '{search}'"' over ssh onto linux machine.
     Note this returns the full file path, not relative to 'directory'.
 
     Parameters
@@ -120,7 +120,7 @@ def find_remote(user, machine, directory, serach, port=22):
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(machine, username=user, port=port)
 
-    command = f"find {directory} -name '{serach}'"
+    command = f"find {directory} -name '{search}'"
     stdin, stdout, stderr = ssh.exec_command(command)
     stdout = stdout.read().decode(errors='ignore'), stderr.read().decode(errors='ignore')
 


### PR DESCRIPTION
The dtypes in the db for pi_status_munkholmen were a mix of floats and ints.

I have changed this (using the copy_measurement.py script) so they are all floats. The reason, is that we got an error with the dtypes when we switched to the methane-ingest branch. A bit odd that we got that error, and I don't fully understand it, but I assume that numbers are floats, so it could be burried in the code somewhere that I forget about.

NOTE: On this branch we do not ingest this file to the backup influx (on config.sintef_influx_pc). This is a somewhat serious problem, but harder to solve.